### PR TITLE
Add option to use device vendor name to be dynamically passed through

### DIFF
--- a/utils/fmoconfig.py
+++ b/utils/fmoconfig.py
@@ -199,8 +199,11 @@ class FMOConfig_Manager(object, metaclass=Singleton):
                 if (dpconfig.get("enable",False)):
                     devicelist = dpconfig.get("devices", [])
                     for device in devicelist:
-                        device["vendorId"]=device.pop("vendorid")
-                        device["productId"]=device.pop("productid")
+                        if "vendorid" in device and "productid" in device:
+                            device["vendorId"]=device.pop("vendorid")
+                            device["productId"]=device.pop("productid")
+                        elif "vendorname" in device:
+                            device["vendorName"]=device.pop("vendorname")                            
                     vmddplist.append({'name': vmname, 'qmpSocket': '/var/lib/microvms/'+vmname+'/'+vmname+'.sock', 'usbPassthrough': devicelist})
             except Exception as e:
                 continue


### PR DESCRIPTION
- Add -vn option for vendorname in creating rules
- Modify reading-rules function to match new vendorname rules